### PR TITLE
Strengthen manuscript style and figure safeguards

### DIFF
--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -161,6 +161,34 @@ def validate_skill_resources() -> None:
         require_file(required)
     load_json("skills/mechanical-engineering-research/assets/templates/reproducibility-manifest.json")
 
+    style_files = {
+        "skills/mechanical-engineering-research/SKILL.md": [
+            "For a manuscript authored or supervised by Han Hu",
+        ],
+        "skills/mechanical-engineering-research/references/paper-writing-style.md": [
+            "Paragraph And Sentence Construction",
+            "Do not use the word \"panel\" in manuscript text or captions",
+            "Avoid one-sentence paragraphs",
+        ],
+        "skills/mechanical-engineering-research/references/scientific-figure-and-artifact-qa.md": [
+            "Write captions as complete, descriptive prose",
+            "max, k=2 uncertainty",
+        ],
+        "skills/mechanical-engineering-research/references/han-hu-research-style.md": [
+            "Use Arial for all figure text",
+            "Refer to subfigures as `Fig. 6a`",
+        ],
+        "skills/mechanical-engineering-research/references/manuscript-revision-submission.md": [
+            "Do not substitute a passive limitation statement",
+            "Recommend the substantive response",
+        ],
+    }
+    for path, required_phrases in style_files.items():
+        content = require_file(path).read_text(encoding="utf-8")
+        for phrase in required_phrases:
+            if phrase not in content:
+                fail(f"{path} is missing manuscript-style safeguard: {phrase}")
+
 
 def main() -> int:
     validate_docs()

--- a/skills/mechanical-engineering-research/SKILL.md
+++ b/skills/mechanical-engineering-research/SKILL.md
@@ -69,6 +69,8 @@ Read only the references needed for the task.
 
 For document, PDF, spreadsheet, or presentation files, also use any available format-specific skill for file manipulation and rendering. Keep this skill responsible for engineering validity and scientific interpretation.
 
+For a manuscript authored or supervised by Han Hu, read [han-hu-research-style.md](references/han-hu-research-style.md) together with the task-specific paper and figure references even when the request does not explicitly ask for style matching.
+
 For iterative peer-review work, use `reviewer-author-loop` as the process scaffold when available. Apply this skill to physics, equations, instrumentation, uncertainty, data reduction, figures, modeling assumptions, and claim support.
 
 ## Output Contract

--- a/skills/mechanical-engineering-research/references/han-hu-research-style.md
+++ b/skills/mechanical-engineering-research/references/han-hu-research-style.md
@@ -11,8 +11,24 @@ Use this reference only when the user explicitly asks to match Han Hu's establis
 - State the technical finding, mechanism, limitation, or need directly. Use `indicates` for supported interpretation, `suggests` for weaker inference, and `demonstrates` only for direct evidence.
 - Make figures, tables, and equations carry the argument. Give related figures distinct roles in the prose.
 - Prefer concise final communication, but do not reduce scientific depth for a high-risk audit, review, or revision.
+- Use professional publication language without casual expressions, reader guidance, prompt-like statements, or meta-commentary about wording. State the technical meaning directly.
+- Avoid excessive colons and semicolons. Prefer connected complete sentences, using i), ii), and iii) for compact enumerations when needed.
+- Avoid one-sentence paragraphs and strings of very short paragraphs. Each paragraph should develop one central topic through evidence, interpretation, and implication.
+- Use short noun phrases for section titles. Do not place conclusions in headings.
+- Refer to subfigures as `Fig. 6a`, `Fig. 6b`, and so forth. Do not use "panel" in manuscript text or captions.
 
 Use [paper-writing-style.md](paper-writing-style.md) for paper structure, [literature-review.md](literature-review.md) for synthesis, and [manuscript-revision-submission.md](manuscript-revision-submission.md) for revision/submission details. Do not duplicate their checklists here.
+
+## Figure And Caption Preferences
+
+- Use Arial for all figure text unless the target journal explicitly requires another typeface. Keep font sizes legible and consistent at final publication dimensions.
+- Italicize variable symbols. Keep units and subscript or superscript descriptors in roman type unless a mathematical convention or journal rule requires otherwise.
+- Place subfigure labels `(a)`, `(b)`, and so forth outside the plotting box near the upper-left corner, aligned just above the y-axis label and level with the top of the axes with a small cushion, when the journal layout permits.
+- Give every subplot a unique sequential label. Remove excessive whitespace and prevent labels, legends, annotations, and data from overlapping.
+- Write descriptive captions as continuous prose. Identify the quantities, conditions, subfigure mapping, visual encodings, uncertainty treatment, and data-reduction choices without using the word "panel."
+- Discuss figures with enough detail to identify both axes, the experimental or modeled conditions, the principal observation, and the physical interpretation.
+- Use publication-facing operating conditions rather than internal case IDs. Use author-year labels for individual literature datasets.
+- Do not use a generic corner uncertainty marker unless it is explicitly requested and its meaning is unambiguous.
 
 ## Reviews Of Data, Software, And Benchmarks
 

--- a/skills/mechanical-engineering-research/references/manuscript-revision-submission.md
+++ b/skills/mechanical-engineering-research/references/manuscript-revision-submission.md
@@ -32,6 +32,8 @@ Location of changes: [section, paragraph, equation, table, figure, or reference]
 
 For major changes, quote or closely reproduce the revised text. Avoid entries such as "Changes made" without enough detail to verify the response. If a methodological concern requires new analysis, data, validation, or uncertainty treatment, do that work when feasible; do not close it through wording alone.
 
+When the requested evidence is available locally or through authorized sources, address a substantive reviewer concern through the needed analysis, data extraction, model evaluation, figure revision, or source verification. Do not substitute a passive limitation statement or weaker framing merely because the substantive response takes more time. If the author has not specified the preferred effort level and the alternatives differ materially in time or scope, present i) a prose-only response with its unresolved limitation and ii) a substantive response with the required work. Recommend the substantive response and proceed with it when the user has requested a thorough revision. Pause only when the work meets an explicit human-pause condition, requires unavailable evidence, or requires an author-positioning decision.
+
 Prefer a formal narrative response with editor/reviewer headings. A tracking matrix may support the work but should not replace the submitted response. Start from [response-to-reviewers.md](../assets/templates/response-to-reviewers.md) and use [reviewer-response-matrix.csv](../assets/templates/reviewer-response-matrix.csv) internally when useful.
 
 ## Highlighted Manuscript

--- a/skills/mechanical-engineering-research/references/paper-writing-style.md
+++ b/skills/mechanical-engineering-research/references/paper-writing-style.md
@@ -15,6 +15,18 @@ The preferred style is:
 - Specific: include conditions, geometry, materials, metrics, regimes, uncertainty, and validation where relevant.
 - Careful: separate measured results, model predictions, interpretation, and speculation.
 
+Use professional journal language throughout. Remove conversational expressions, writing advice addressed to the reader, prompt-like commentary, and sentences that discuss how a phrase should be interpreted. State the scientific content directly.
+
+Use short noun phrases for section and subsection titles. Do not write titles as complete sentences or embed a result or conclusion in a heading.
+
+## Paragraph And Sentence Construction
+
+Give each paragraph one central topic that is distinct from the paragraphs around it. State that topic near the beginning, develop it with connected evidence and interpretation, and close with its scientific implication or a transition. Avoid one-sentence paragraphs and repeated very short paragraphs unless the journal format requires them. Merge adjacent material only when it serves the same central topic.
+
+Prefer complete sentences over colon-led explanations or semicolon-linked chains. Use colons and semicolons only when they improve precision and cannot be replaced cleanly by a sentence break. When a sentence must enumerate alternatives, use i), ii), and iii). For a longer sequence, introduce the topic in a complete sentence and develop it with ordered sentences such as "First," "Second," and "Third."
+
+Avoid stock connective words when they do not express a real logical relation. Words such as "consequently," "enable," and "establish" should appear only when their exact meaning is supported. Vary sentence length without creating fragments, repetitive templates, or AI-like prose.
+
 ## Abstract Pattern
 
 Use a dense but logical abstract structure:
@@ -113,6 +125,8 @@ For each major figure or table, develop this logic without forcing stock sentenc
 
 Use varied transitions that make the analysis cumulative. Avoid repeating canned phrases such as "Figure X shows," "It is observed that," or "Physically, this can be attributed to" in every paragraph.
 
+Refer to a subfigure directly as `Fig. 8b`, not as "panel (b)," "the second panel," or `Fig. 8(b)`. Do not use the word "panel" in manuscript text or captions. A substantive figure discussion should identify the horizontal and vertical variables, the operating conditions or data source, the observed relationship, and the physical interpretation or limitation. Do not rely on a brief statement such as "Fig. 8b compares the frequencies."
+
 Do not present plots as isolated results. Each figure should either answer a question, motivate the next analysis, or close a gap from the introduction.
 
 ## Baseline To Generalization
@@ -209,3 +223,7 @@ Before finalizing a paper draft, check:
 - Does each figure discussion include observation, mechanism, and implication?
 - Are model or AI results interpreted physically rather than only statistically?
 - Does the conclusion state concrete findings rather than rephrasing the abstract?
+- Does every paragraph have one developed central topic, with no avoidable one-sentence paragraphs?
+- Are headings short noun phrases rather than sentences or conclusions?
+- Are subfigures cited as `Fig. 8b`, with no use of "panel" in text or captions?
+- Are casual, prompt-like, meta-writing, colon-heavy, semicolon-heavy, and formulaic AI expressions absent?

--- a/skills/mechanical-engineering-research/references/scientific-figure-and-artifact-qa.md
+++ b/skills/mechanical-engineering-research/references/scientific-figure-and-artifact-qa.md
@@ -24,6 +24,14 @@ Render at the actual manuscript or slide size and inspect:
 
 Do not encode one typeface, forced float specifier, or punctuation rule as universal. Follow the venue and verify the rendered result.
 
+For multi-plot figures, assign one unique subfigure label to every plot. Place labels consistently outside the axes when the venue permits, with enough clearance from axis labels and neighboring content. Check that labels, legends, annotations, and curves do not overlap and that subplot spacing does not create excessive unused space. Increase the rendered font size or revise the layout when text is not legible at final publication width.
+
+Write captions as complete, descriptive prose. State the measured or calculated quantities, operating conditions, subfigure mapping, line or marker conventions, uncertainty treatment, and important data-reduction choices needed to interpret the figure. Avoid terse fragments and constructions such as "Panel (a) shows." Refer to subfigures with `(a)`, `(b)`, and so forth inside the caption without calling them panels.
+
+Use publication-facing condition labels in figures and legends rather than unexplained internal case identifiers. Label literature datasets with source-specific author-year identifiers when multiple sources are plotted; do not collapse them into a generic "literature" series.
+
+Represent uncertainty only when its statistical meaning and relation to the plotted data are clear. Do not add a generic corner error bar or a label such as "max, k=2 uncertainty" unless the author requests that convention and the caption defines the quantity, coverage factor, and applicability. Prefer point-specific bars, bands, or a clearly explained representative indicator.
+
 ## Manuscript Integration
 
 - Cite and interpret every main figure and table.


### PR DESCRIPTION
## Summary
- apply Han Hu's manuscript style profile automatically for papers authored or supervised by him
- add paragraph, sentence, heading, figure-reference, caption, typography, layout, and uncertainty safeguards
- require substantive reviewer responses when available evidence permits additional analysis
- add repository validation checks for the retained preferences

## Validation
- `python scripts/validate_repo.py`
- `python -m unittest discover -s tests -v`
- official `quick_validate.py` skill validation
- placeholder and prompt-residue scan